### PR TITLE
Add React context to pass alert function

### DIFF
--- a/src/components/Body/index.js
+++ b/src/components/Body/index.js
@@ -5,23 +5,9 @@ function sayHello() {
 }
 
 export default function Body({children}) {
-
-  const childrenWithSendAlert = React.Children.map(
-    children,
-    (child) => {
-      if (! React.isValidElement(child)) {
-        return child;
-      }
-      return React.cloneElement(
-        child,
-        { sendAlert: sayHello }
-      );
-    }
-  );
-
   return (
-    <div className="my-body">
-      {childrenWithSendAlert}
-    </div>
+      <div className="my-body">
+        {children}
+      </div>
   );
 }

--- a/src/components/Body/index.js
+++ b/src/components/Body/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import {AlertContext} from '../../contexts/alert-context';
 
 function sayHello() {
   alert('hello');
@@ -6,8 +7,10 @@ function sayHello() {
 
 export default function Body({children}) {
   return (
+    <AlertContext.Provider value={sayHello}>
       <div className="my-body">
         {children}
       </div>
+    </AlertContext.Provider>
   );
 }

--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -1,4 +1,8 @@
-export default function Button({children, sendAlert}) {
+import {useContext} from 'react';
+import {AlertContext} from '../../contexts/alert-context';
+
+export default function Button({children}) {
+  const sendAlert = useContext(AlertContext);
   return (
     <button onClick={sendAlert}>
       {children}

--- a/src/components/Sidebar/index.js
+++ b/src/components/Sidebar/index.js
@@ -1,23 +1,8 @@
-import React from 'react';
-
-export default function Sidebar({children, sendAlert}) {
-
-  const childrenWithSendAlert = React.Children.map(
-    children,
-    (child) => {
-      if (! React.isValidElement(child)) {
-        return child;
-      }
-      return React.cloneElement(
-        child,
-        { sendAlert }
-      );
-    }
-  );
+export default function Sidebar({children}) {
 
   return (
     <div className="my-side">
-      {childrenWithSendAlert}
+      {children}
     </div>
   );
 }

--- a/src/contexts/alert-context.js
+++ b/src/contexts/alert-context.js
@@ -1,0 +1,3 @@
+import React from 'react';
+
+export const AlertContext = React.createContext();


### PR DESCRIPTION
Instead of passing our `sendAlert()` function through the in-between `<Sidebar>` component, we are using React context to pass the value directly from `<Body>` to `<Button`